### PR TITLE
fix: commit quick error

### DIFF
--- a/magit-gptcommit.el
+++ b/magit-gptcommit.el
@@ -442,13 +442,11 @@ Executed in the context of the commit message buffer."
     (magit-gptcommit--add-hook-run-once 'git-commit-setup-hook hook)
     (magit-commit-create)))
 
-
 (defun magit-gptcommit-commit-quick ()
   "Accept gptcommit message and make a commit with current staged."
   (interactive)
   (if-let ((message (magit-repository-local-get 'magit-gptcommit--last-message)))
-      (magit-run-git "commit" "-m"
-                     (funcall magit-gptcommit-process-commit-message-function message nil))
+      (magit-run-git "commit" "-m" message)
     (user-error "No last gptcommit message found")))
 
 ;;;; response handling


### PR DESCRIPTION
`magit-gptcommit-commit-quick` doesn't operate in a buffer so `magit-gptcommit--process-commit-message` cannot be used in that context.