### PR TITLE
fix: check buf is alive before access it

### DIFF
--- a/magit-gptcommit.el
+++ b/magit-gptcommit.el
@@ -382,8 +382,8 @@ NO-CACHE is non-nil if cache should be ignored."
     (message "%s" worker)
     (dolist (pair (oref worker sections))
       (let ((buf (car pair)))
-        (with-current-buffer buf
-          (setq-local magit-inhibit-refresh nil))))
+        (when (buffer-live-p buf)
+          (setf (buffer-local-value 'magit-inhibit-refresh buf) nil))))
     (magit-repository-local-delete 'magit-gptcommit--active-worker repository)
     (llm-cancel-request (oref worker llm-request))))
 


### PR DESCRIPTION
Fix an error that occurs if the Magit buffer is killed and re-opened. 
```elisp
Debugger entered--Lisp error: (error "Selecting deleted buffer")
  magit-gptcommit-abort()
  magit-gptcommit--insert(staged)
  magit-gptcommit--status-insert-gptcommit()
  magit-run-section-hook(magit-status-sections-hook)
  magit-status-refresh-buffer()
  magit-refresh-buffer()
  magit-setup-buffer-internal(magit-status-mode nil ((magit-buffer-diff-args ("--no-ext-diff")) (magit-buffer-diff-files nil) (magit-buffer-log-args ("-n256" "--decorate")) (magit-buffer-log-files nil)))
  magit-status-setup-buffer("/home/st/src/key-chord/")
  magit-status(nil ((61 . 31) (("/home/st/src/key-chord/" "symbolic-ref" #("refs/remotes/origin/HEAD" 13 19 (face magit-branch-remote font-lock-face magit-branch-remote))) . "refs/remotes/origin/master") (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/tags/origin/HEAD")) (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/tags/origin/master")) (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/tags/master")) (("/home/st/src/key-chord/" "rev-parse" "--short" "HEAD~") . "b288c45") (("/home/st/src/key-chord/" "rev-parse" "--short" "HEAD") . "fecc468") (("/home/st/src/key-chord/" "rev-parse" "--verify" "HEAD~10") . "bab58b8e1194756faebddeaf0867d1946eeceb3c") (("/home/st/src/key-chord/" . magit--insert-pushremote-log-p)) (("/home/st/src/key-chord/" magit-get-upstream-branch nil) . #("origin/master" 0 13 (face magit-branch-remote font-lock-face magit-branch-remote))) (("/home/st/src/key-chord/" magit-get-push-branch nil nil) . #("origin/master" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote))) (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/stash")) (("/home/st/src/key-chord/" "rev-parse" "--is-bare-repository") . "false\n") (("/home/st/src/key-chord/" "describe" "--contains" "HEAD")) (("/home/st/src/key-chord/" "describe" "--long" "--tags") . "0.7.1-13-gfecc468") (("/home/st/src/key-chord/" "rev-parse" "--verify" #("origin/master" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote))) . "fecc46817961a441f631a6de5aacebc7a16c0e1a") (("/home/st/src/key-chord/" magit-get-push-branch "master" nil) . #("origin/master" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote))) (("/home/st/src/key-chord/" "log" "--no-walk" "--format=%s" #("origin/master^{commit}" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote)) "--") . "fix: disable key-chord-in-macros by default") (("/home/st/src/key-chord/" magit-get-upstream-branch "master") . #("origin/master" 0 13 (face magit-branch-remote font-lock-face magit-branch-remote))) (("/home/st/src/key-chord/" "rev-parse" "--verify" "--abbrev-ref" "master@{upstream}") . "origin/master") (("/home/st/src/key-chord/" "log" "--no-walk" "--format=%h %s" "HEAD^{commit}" "--") . "fecc468 fix: disable key-chord-in-macros by default") (("/home/st/src/key-chord/" "symbolic-ref" "--short" "HEAD") . "master") (("/home/st/src/key-chord/" "rev-parse" "--verify" "HEAD") . "fecc46817961a441f631a6de5aacebc7a16c0e1a") (("/home/st/src/key-chord/" "symbolic-ref" "--short" "refs/remotes/origin/HEAD") . "origin/master") (("/home/st/src/key-chord/" forge-get-repository :known?)) (("/home/st/src/key-chord/" forge-get-repository :tracked?)) (("/home/st/src/key-chord/" "remote" "get-url" "origin") . "ssh://git@github.com/lemonbreezes/key-chord.git") (("/home/st/src/key-chord/" . config) . #<hash-table equal 43/96 0x3d70ac ...>) (("/home/st/src/key-chord/" magit-gitdir) . "/home/st/src/key-chord/.git/") (("/home/st/src/key-chord/" "rev-parse" "--git-dir") . ".git") (("/home/st/src/key-chord/" . magit-toplevel) . "/home/st/src/key-chord/") (("/home/st/src/key-chord/" "rev-parse" "--show-toplevel") . "/home/st/src/key-chord")))
  funcall-interactively(magit-status nil ((61 . 31) (("/home/st/src/key-chord/" "symbolic-ref" #("refs/remotes/origin/HEAD" 13 19 (face magit-branch-remote font-lock-face magit-branch-remote))) . "refs/remotes/origin/master") (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/tags/origin/HEAD")) (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/tags/origin/master")) (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/tags/master")) (("/home/st/src/key-chord/" "rev-parse" "--short" "HEAD~") . "b288c45") (("/home/st/src/key-chord/" "rev-parse" "--short" "HEAD") . "fecc468") (("/home/st/src/key-chord/" "rev-parse" "--verify" "HEAD~10") . "bab58b8e1194756faebddeaf0867d1946eeceb3c") (("/home/st/src/key-chord/" . magit--insert-pushremote-log-p)) (("/home/st/src/key-chord/" magit-get-upstream-branch nil) . #("origin/master" 0 13 (face magit-branch-remote font-lock-face magit-branch-remote))) (("/home/st/src/key-chord/" magit-get-push-branch nil nil) . #("origin/master" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote))) (("/home/st/src/key-chord/" "rev-parse" "--verify" "refs/stash")) (("/home/st/src/key-chord/" "rev-parse" "--is-bare-repository") . "false\n") (("/home/st/src/key-chord/" "describe" "--contains" "HEAD")) (("/home/st/src/key-chord/" "describe" "--long" "--tags") . "0.7.1-13-gfecc468") (("/home/st/src/key-chord/" "rev-parse" "--verify" #("origin/master" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote))) . "fecc46817961a441f631a6de5aacebc7a16c0e1a") (("/home/st/src/key-chord/" magit-get-push-branch "master" nil) . #("origin/master" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote))) (("/home/st/src/key-chord/" "log" "--no-walk" "--format=%s" #("origin/master^{commit}" 0 13 (font-lock-face magit-branch-remote face magit-branch-remote)) "--") . "fix: disable key-chord-in-macros by default") (("/home/st/src/key-chord/" magit-get-upstream-branch "master") . #("origin/master" 0 13 (face magit-branch-remote font-lock-face magit-branch-remote))) (("/home/st/src/key-chord/" "rev-parse" "--verify" "--abbrev-ref" "master@{upstream}") . "origin/master") (("/home/st/src/key-chord/" "log" "--no-walk" "--format=%h %s" "HEAD^{commit}" "--") . "fecc468 fix: disable key-chord-in-macros by default") (("/home/st/src/key-chord/" "symbolic-ref" "--short" "HEAD") . "master") (("/home/st/src/key-chord/" "rev-parse" "--verify" "HEAD") . "fecc46817961a441f631a6de5aacebc7a16c0e1a") (("/home/st/src/key-chord/" "symbolic-ref" "--short" "refs/remotes/origin/HEAD") . "origin/master") (("/home/st/src/key-chord/" forge-get-repository :known?)) (("/home/st/src/key-chord/" forge-get-repository :tracked?)) (("/home/st/src/key-chord/" "remote" "get-url" "origin") . "ssh://git@github.com/lemonbreezes/key-chord.git") (("/home/st/src/key-chord/" . config) . #<hash-table equal 43/96 0x3d70ac ...>) (("/home/st/src/key-chord/" magit-gitdir) . "/home/st/src/key-chord/.git/") (("/home/st/src/key-chord/" "rev-parse" "--git-dir") . ".git") (("/home/st/src/key-chord/" . magit-toplevel) . "/home/st/src/key-chord/") (("/home/st/src/key-chord/" "rev-parse" "--show-toplevel") . "/home/st/src/key-chord")))
  call-interactively(magit-status)
  (let* ((buffer-file-path (if buffer-file-name (progn (file-relative-name buffer-file-name (locate-dominating-file buffer-file-name ".git"))))) (default-directory (or (condition-case nil (progn (project-root (project-current))) (error nil)) (condition-case nil (progn (doom-project-root)) (error nil)) buffer-file-path default-directory)) (section-ident (cons (cons 'file buffer-file-path) '((unstaged) (status))))) (call-interactively #'magit-status) (let ((ignore-window-parameters t)) (delete-other-windows)) (if buffer-file-path (progn (goto-char (point-min)) (let ((--cl-block-nil-- (cons '--cl-block-nil-- nil))) (catch --cl-block-nil-- (while (not (if ... ...)) (condition-case nil (magit-section-forward) (error ...))) nil)))))
  #f(lambda () [t] "Open a `magit-status' buffer and close the other window so only Magit is visible.\nIf a file was visited in the buffer that was active when this\ncommand was called, go to its unstaged changes section." (interactive nil) (require 'project) (let* ((buffer-file-path (if buffer-file-name (progn (file-relative-name buffer-file-name (locate-dominating-file buffer-file-name ".git"))))) (default-directory (or (condition-case nil (progn (project-root (project-current))) (error nil)) (condition-case nil (progn (doom-project-root)) (error nil)) buffer-file-path default-directory)) (section-ident (cons (cons 'file buffer-file-path) '((unstaged) (status))))) (call-interactively #'magit-status) (let ((ignore-window-parameters t)) (delete-other-windows)) (if buffer-file-path (progn (goto-char (point-min)) (let ((--cl-block-nil-- (cons '--cl-block-nil-- nil))) (catch --cl-block-nil-- (while (not (if (equal section-ident (magit-section-ident (magit-current-section))) (progn (magit-section-show (magit-current-section)) t))) (condition-case nil (magit-section-forward) (error (throw --cl-block-nil-- (magit-status-goto-initial-section-1))))) nil))))))()
  apply(#f(lambda () [t] "Open a `magit-status' buffer and close the other window so only Magit is visible.\nIf a file was visited in the buffer that was active when this\ncommand was called, go to its unstaged changes section." (interactive nil) (require 'project) (let* ((buffer-file-path (if buffer-file-name (progn (file-relative-name buffer-file-name ...)))) (default-directory (or (condition-case nil (progn ...) (error nil)) (condition-case nil (progn ...) (error nil)) buffer-file-path default-directory)) (section-ident (cons (cons 'file buffer-file-path) '(... ...)))) (call-interactively #'magit-status) (let ((ignore-window-parameters t)) (delete-other-windows)) (if buffer-file-path (progn (goto-char (point-min)) (let ((--cl-block-nil-- ...)) (catch --cl-block-nil-- (while ... ...) nil)))))) nil)
  cae-unpackaged-magit-status()
  cae-unpackaged-magit-save-buffer-show-status()
  funcall-interactively(cae-unpackaged-magit-save-buffer-show-status)
  command-execute(cae-unpackaged-magit-save-buffer-show-status)
```